### PR TITLE
Parser fix, update year in generated HTML

### DIFF
--- a/app/services/epure/parser.rb
+++ b/app/services/epure/parser.rb
@@ -80,7 +80,7 @@ module Epure
                   e.start_min   = m_when[3].to_i
                   e.end_hour    = m_when[4].to_i
                   e.end_min     = m_when[5].to_i
-                elsif m_when = where_when.match(/(.{2})(?:\/(T(?:P|N)?))? (\d{2}):(\d{2})-(\d{2}):(\d{2})/u)
+                elsif m_when = where_when.match(/(.{2})(?:\/(T(?:P|N)?))?(?:.*)? (\d{2}):(\d{2})-(\d{2}):(\d{2})/u)
                   e.week_day    = WEEK_DAYS[m_when[1]]
                   e.week        = WEEKS[m_when[2] || ""]
                   e.start_hour  = m_when[3].to_i

--- a/app/views/exports/normal.html.haml
+++ b/app/views/exports/normal.html.haml
@@ -35,6 +35,6 @@
         = link_to Epure::Config::URL
         \| Tymon Tobolski
         = "(#{link_to "http://teamon.eu"})".html_safe
-        2010-2012
+        2010-2014
 
 


### PR DESCRIPTION
It seems they changed a bit format of date, my fix captures everything after TP/TN to next space. For example: TN+1/2, that +1/2 was not captured, so it broke the parser.
